### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 ---
 name: Release
+permissions:
+  contents: write
 on:
   workflow_run:
     workflows: ["Build and test"]


### PR DESCRIPTION
Potential fix for [https://github.com/nicholas-fedor/shoutrrr-action/security/code-scanning/38](https://github.com/nicholas-fedor/shoutrrr-action/security/code-scanning/38)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are required:
- `contents: write` for tagging and pushing changes.
- `issues: write` for adding comments to issues (if applicable).
- `pull-requests: write` for managing pull requests (if applicable).

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `release` job. In this case, adding it at the root level is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
